### PR TITLE
Docs: clarify install, updating, and submodule steps (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,39 +2,46 @@
 
 [![OpenCode Security Scan](https://github.com/Keith-CY/my-crazy-skills/actions/workflows/opencode-security-scan.yml/badge.svg?branch=main)](https://github.com/Keith-CY/my-crazy-skills/actions/workflows/opencode-security-scan.yml)
 
-## Quick install
+Collection of AI "skills" tracked as git submodules. Categories live under `skills/` and reflect the current organization.
 
-**Run this once to link skills globally for Codex:**
+This repo is meant to be *linked* into an agent's skills directory (global or per-project) via `INSTALL.sh`.
+
+## Install
+
+### Quick install (curl)
+
+If you use `curl | sh`, consider inspecting `INSTALL.sh` first.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh
 ```
 
-Notes:
-- `curl | sh` auto-clones to `~/.cache/my-crazy-skills` if no local `skills/` is found.
-- Target other agents:
-  - Claude:
-    ```bash
-    curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --claude
-    ```
-  - Gemini:
-    ```bash
-    curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --gemini
-    ```
-  - OpenCode:
-    ```bash
-    curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --opencode
-    ```
-- Per-project link (Codex example):
-  ```bash
-  curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --project /path/to/project
-  ```
-- Per-project + target (Claude example):
-  ```bash
-  curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --claude --project /path/to/project
-  ```
+By default this links skills globally for Codex (`~/.codex/skills`).
 
-Collection of AI skills tracked as git submodules. Categories live under `skills/` and reflect the current organization.
+### Install from a local clone (recommended)
+
+```bash
+git clone --recurse-submodules https://github.com/Keith-CY/my-crazy-skills
+cd my-crazy-skills
+./INSTALL.sh --help
+./INSTALL.sh
+```
+
+### Notes and examples
+
+- If no local `skills/` directory is found, the installer auto-clones to `~/.cache/my-crazy-skills`.
+- Existing non-symlink destinations are backed up with a `.bak.<timestamp>` suffix.
+- Target other agents:
+  - Claude: `curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --claude`
+  - Gemini: `curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --gemini`
+  - OpenCode: `curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --opencode`
+- Per-project link (Codex example): `curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --project /path/to/project`
+- Per-project + target (Claude example): `curl -fsSL https://raw.githubusercontent.com/Keith-CY/my-crazy-skills/main/INSTALL.sh | sh -s -- --claude --project /path/to/project`
+
+## Updating
+
+- Local clone: `git pull --recurse-submodules` (or `git submodule update --init --recursive`).
+- `curl | sh` installs: re-run the installer (it reuses `~/.cache/my-crazy-skills` if present).
 
 ## Layout
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -15,7 +15,7 @@ This directory contains AI skills organized by category. Each skill is added as 
 
 ## Adding a New Skill
 
-To add a new skill, use the following command:
+To add a new skill, add it as a submodule under the appropriate category:
 
 ```bash
 git submodule add <repository_url> skills/<category>/<skill_name>
@@ -24,6 +24,12 @@ git submodule add <repository_url> skills/<category>/<skill_name>
 Example:
 ```bash
 git submodule add https://github.com/example/playwright-skill skills/frontend/playwright
+```
+
+After adding, make sure submodules are initialized locally:
+
+```bash
+git submodule update --init --recursive
 ```
 
 ## Automatic Updates


### PR DESCRIPTION
## Summary
Polish repo docs to make installation, updating, and adding new skills clearer and safer.

## What changed
- `README.md`: add a short intro, reorganize install instructions (including a recommended local-clone flow), consolidate examples, add an “Updating” section, and mention the installer's `.bak.<timestamp>` backup behavior.
- `skills/README.md`: clarify the “add a new skill” workflow (as a git submodule) and document the follow-up `git submodule update --init --recursive` step.

## Why
Task context was “Refine the document”. The README previously jumped straight into `curl | sh` without framing what it does, offering a safer local-clone option, or explaining how to update. The skills README also omitted the common post-add submodule initialization step. These changes reduce setup friction for first-time users and keep documentation aligned with the actual `INSTALL.sh` behavior.

## Implementation details
- Documentation-only change; no scripts, workflows, or submodule references were modified.
- Preserves the auto-generated skills list markers (`<!-- SKILLS-LIST:START -->`/`<!-- SKILLS-LIST:END -->`) so the update workflow can continue managing that section.

This PR was written using [Vibe Kanban](https://vibekanban.com)
